### PR TITLE
fix bug in timer guard

### DIFF
--- a/ac.soton.eventb.emf.components.generator/src/ac/soton/eventb/emf/components/generator/strings/Strings.java
+++ b/ac.soton.eventb.emf.components.generator/src/ac/soton/eventb/emf/components/generator/strings/Strings.java
@@ -138,7 +138,7 @@ public static String CTXT_NAME(Component cp) {
  
  public static String TE_PW_READY_PARAM_NAME;
  public static String TE_PW_READY_PARAM_NAME(PortWake pw){
- 	return bind(TE_PW_READY_PARAM_NAME,OS_NAME(pw));
+ 	return bind(TE_PW_READY_PARAM_NAME, makeValidIdentifier(getOSNameFromOp(pw)));
  }
  public static String TE_PW_READY_GUARD_NAME;
  public static String TE_PW_READY_GUARD_NAME(PortWake pw){

--- a/ac.soton.eventb.emf.components.generator/src/ac/soton/eventb/emf/components/generator/strings/Strings.properties
+++ b/ac.soton.eventb.emf.components.generator/src/ac/soton/eventb/emf/components/generator/strings/Strings.properties
@@ -48,7 +48,7 @@ TE_PW_DONE_GUARD_NAME = {0}_Done__grd
 TE_PW_DONE_GUARD_PRED = {0} = TRUE \u2228 {1} = FALSE
 TE_PW_READY_PARAM_NAME = {0}_Ready
 TE_PW_READY_GUARD_NAME = {0}_Ready__grd
-TE_PW_READY_GUARD_PRED = {0} = bool({1} \u2209 {2})
+TE_PW_READY_GUARD_PRED = {0} = bool({1} \u2208 {2})
 TE_SW_DONE_GUARD_NAME = {0}_Done__grd
 TE_SW_DONE_GUARD_PRED = {0} \u2208 dom({1}) \u21d2 {1}({0}) \u2208 {2} 
 TE_MD_DONE_GUARD_NAME = {0}_Done__grd


### PR DESCRIPTION
the sense of the boolean parameter is reversed - ready s.b. when current time is in the dom.
also fixed param name - remove ...DONE